### PR TITLE
fix(table): remove table, and render empty chart

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,6 +132,12 @@ module.exports = {
       "rules": {
         "react/no-unused-prop-types": "off"
       }
+    },
+    {
+      "files": ["src/components/IndexButtonBar.jsx"],
+      "rules": {
+        "react/no-danger": "off"
+      }
     }
   ],
 };

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -189,7 +189,22 @@
       },
       "dataset": {
         "chartType": "pie",
-        "title": "Dataset",
+        "title": "Resources",
+        "chartRow": 0
+      },
+      "data_format": {
+        "chartType": "bar",
+        "title": "Data Format",
+        "chartRow": 0
+      },
+      "data_type": {
+        "chartType": "pie",
+        "title": "Data Type",
+        "chartRow": 0
+      },
+      "experimental_strategies": {
+        "chartType": "bar",
+        "title": "Experimental Strategies",
         "chartRow": 0
       },
       "species": {
@@ -200,41 +215,21 @@
       "gender": {
         "chartType": "pie",
         "title": "Gender",
-        "chartRow": 0
-      },
-      "status": {
-        "chartType": "pie",
-        "title": "HIV Status",
-        "chartRow": 0
-      },
-      "strain": {
-        "chartType": "pie",
-        "title": "Strain",
-        "chartRow": 0
-      },
-      "amikacin_res_phenotype": {
-        "chartType": "bar",
-        "title": "Amikacin Res Phenotype",
         "chartRow": 1
       },
-      "capreomycin_res_phenotype": {
+      "race": {
         "chartType": "pie",
-        "title": "Capreomycin Res Phenotype",
+        "title": "Race",
         "chartRow": 1
       },
-      "isoniazid_res_phenotype": {
-        "chartType": "bar",
-        "title": "Isoniazid Res Phenotype",
-        "chartRow": 1
-      },
-      "kanamycin_res_phenotype": {
+      "ethnicity": {
         "chartType": "pie",
-        "title": "Kanamycin Res Phenotype",
+        "title": "Ethnicity",
         "chartRow": 1
       },
-      "ofloxacin_res_phenotype": {
-        "chartType": "bar",
-        "title": "Ofloxacin Res Phenotype",
+      "biospecimen_anatomic_site": {
+        "chartType": "pie",
+        "title": "Biospecimen Anatomic Site",
         "chartRow": 1
       }
     },
@@ -248,16 +243,17 @@
       { "field": "species", "name": "Genus Species" },
       { "field": "submitter_id", "name": "Submitter ID" },
       { "field": "race", "name": "Race" },
-      { "field": "hiv_status", "name": "HIV Status" }
+      { "field": "hiv_status", "name": "HIV Status" },
+      { "field": "study_submitter_id", "name": "Study"}
     ],
     "filterConfig": {
       "tabs": [{
-        "title": "Subject",
-        "fields": ["ethnicity", "gender", "species", "race"]
+        "title": "Resource",
+        "fields": ["dataset", "data_format", "data_type"]
       },
       {
-        "title": "Resource",
-        "fields": ["dataset"]
+        "title": "Subject",
+        "fields": ["ethnicity", "gender", "species", "race", "experimental_strategies"]
       },
       {
         "title": "Diagnosis",
@@ -321,11 +317,6 @@
           "strain"
         ]
       }]
-    },
-    "phenotypeNameMapping": {
-      "NDE: TB": "_type_of_resistances",
-      "NDE: FLU": "virus_subtype",
-      "NDE: AIDS": "status"
     }
   }
 }

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -212,31 +212,6 @@
         "title": "Strain",
         "chartRow": 0
       },
-      "dataset": {
-        "chartType": "pie",
-        "title": "Dataset",
-        "chartRow": 0
-      },
-      "species": {
-        "chartType": "bar",
-        "title": "Genus species",
-        "chartRow": 0
-      },
-      "gender": {
-        "chartType": "pie",
-        "title": "Gender",
-        "chartRow": 0
-      },
-      "status": {
-        "chartType": "bar",
-        "title": "HIV Status",
-        "chartRow": 0
-      },
-      "strain": {
-        "chartType": "pie",
-        "title": "Strain",
-        "chartRow": 0
-      },
       "amikacin_res_phenotype": {
         "chartType": "bar",
         "title": "Amikacin Res Phenotype",

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -55,7 +55,7 @@
       "buttons": [
         {
           "name": "ImmPort",
-          "body": "Explore ImmPort, a resource funded by the NIH, NIAID, and DAIT in support of the NIH mission to share data with the public. Data is provided by NIH-funded programs and other research organizations.",
+          "body": "Visit ImmPort, a resource funded by the NIH, NIAID, and DAIT in support of the NIH mission to share data with the public. Data is provided by NIH-funded programs and other research organizations.",
           "external_link": "https://www.immport.org/home",
           "external_link_text": "Visit Website",
           "logo": "/custom/logo/immport-main-icon.png"
@@ -69,13 +69,13 @@
         {
           "name": "NIAID AIDS Environment",
           "icon": "data-explore",
-          "body": "Explore the NIAID's Multicenter Acquired Immunodeficiency Syndrome Cohort Study (MACS) and Women's Interagency HIV Study (WIHS).",
+          "body": "Explore data from the NIAID Multicenter Acquired Immunodeficiency Syndrome Cohort Study (MACS) and Women's Interagency HIV Study (WIHS).",
           "external_link": "https://qa-test4.planx-pla.net/"
         },
         {
           "name": "NIAID Flu Environment",
           "icon": "data-explore",
-          "body": "Explore a collection of Influenza related studies from the NIAID Divison of Microbiology & Infectious Diseases.",
+          "body": "Explore data from a collection of Influenza related studies funded by the NIAID Divison of Microbiology & Infectious Diseases (DMID).",
           "external_link": "https://qa-flu.planx-pla.net"
         }
       ]

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -189,15 +189,78 @@
       },
       "dataset": {
         "chartType": "pie",
-        "title": "Dataset"
+        "title": "Dataset",
+        "chartRow": 0
       },
       "species": {
         "chartType": "bar",
-        "title": "Genus species"
+        "title": "Genus species",
+        "chartRow": 0
       },
       "gender": {
         "chartType": "pie",
-        "title": "Gender"
+        "title": "Gender",
+        "chartRow": 0
+      },
+      "status": {
+        "chartType": "pie",
+        "title": "HIV Status",
+        "chartRow": 0
+      },
+      "strain": {
+        "chartType": "pie",
+        "title": "Strain",
+        "chartRow": 0
+      },
+      "dataset": {
+        "chartType": "pie",
+        "title": "Dataset",
+        "chartRow": 0
+      },
+      "species": {
+        "chartType": "bar",
+        "title": "Genus species",
+        "chartRow": 0
+      },
+      "gender": {
+        "chartType": "pie",
+        "title": "Gender",
+        "chartRow": 0
+      },
+      "status": {
+        "chartType": "bar",
+        "title": "HIV Status",
+        "chartRow": 0
+      },
+      "strain": {
+        "chartType": "pie",
+        "title": "Strain",
+        "chartRow": 0
+      },
+      "amikacin_res_phenotype": {
+        "chartType": "bar",
+        "title": "Amikacin Res Phenotype",
+        "chartRow": 1
+      },
+      "capreomycin_res_phenotype": {
+        "chartType": "pie",
+        "title": "capreomycin_res_phenotype",
+        "chartRow": 1
+      },
+      "isoniazid_res_phenotype": {
+        "chartType": "bar",
+        "title": "isoniazid_res_phenotype",
+        "chartRow": 1
+      },
+      "kanamycin_res_phenotype": {
+        "chartType": "pie",
+        "title": "kanamycin_res_phenotype",
+        "chartRow": 1
+      },
+      "ofloxacin_res_phenotype": {
+        "chartType": "bar",
+        "title": "ofloxacin_res_phenotype",
+        "chartRow": 1
       }
     },
     "fieldMapping" : [
@@ -208,7 +271,9 @@
       { "field": "ethnicity", "name": "Ethnicity" },
       { "field": "strain", "name": "Strain" },
       { "field": "species", "name": "Genus species" },
-      { "field": "submitter_id", "name": "Submitter ID" }
+      { "field": "submitter_id", "name": "Submitter ID" },
+      { "field": "race", "name": "Race" },
+      { "field": "hiv_status", "name": "HIV Status" }
     ],
     "filterConfig": {
       "tabs": [{
@@ -223,7 +288,8 @@
           "bshcvstat",
           "cd4nadir",
           "status",
-          "hiv_status"
+          "hiv_status",
+          "strain"
         ]
       },
       {
@@ -245,37 +311,9 @@
         "fields": ["dataset"]
       }]
     },
-    "tableConfig": {
-      "fields": [
-        "dataset",
-        "studyAccession",
-        "phenotype",
-        "gender",
-        "ethnicity",
-        "strain",
-        "species",
-        "submitter_id",
-        "race",
-        "arthxbase",
-        "bshbvstat",
-        "bshcvstat",
-        "cd4nadir",
-        "status",
-        "hiv_status",
-        "amikacin_res_phenotype",
-        "capreomycin_res_phenotype",
-        "isoniazid_res_phenotype",
-        "kanamycin_res_phenotype",
-        "ofloxacin_res_phenotype",
-        "pyrazinamide_res_phenotype",
-        "rifampicin_res_phenotype",
-        "rifampin_res_phenotype",
-        "streptomycin_res_phenotype"
-      ]
-    },
     "phenotypeNameMapping": {
       "NDE: TB": "_type_of_resistances",
-      "NDE: Flu": "virus_subtype",
+      "NDE: FLU": "virus_subtype",
       "NDE: AIDS": "status"
     }
   }

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -219,22 +219,22 @@
       },
       "capreomycin_res_phenotype": {
         "chartType": "pie",
-        "title": "capreomycin_res_phenotype",
+        "title": "Capreomycin Res Phenotype",
         "chartRow": 1
       },
       "isoniazid_res_phenotype": {
         "chartType": "bar",
-        "title": "isoniazid_res_phenotype",
+        "title": "Isoniazid Res Phenotype",
         "chartRow": 1
       },
       "kanamycin_res_phenotype": {
         "chartType": "pie",
-        "title": "kanamycin_res_phenotype",
+        "title": "Kanamycin Res Phenotype",
         "chartRow": 1
       },
       "ofloxacin_res_phenotype": {
         "chartType": "bar",
-        "title": "ofloxacin_res_phenotype",
+        "title": "Ofloxacin Res Phenotype",
         "chartRow": 1
       }
     },
@@ -245,7 +245,7 @@
       { "field": "gender", "name": "Gender" },
       { "field": "ethnicity", "name": "Ethnicity" },
       { "field": "strain", "name": "Strain" },
-      { "field": "species", "name": "Genus species" },
+      { "field": "species", "name": "Genus Species" },
       { "field": "submitter_id", "name": "Submitter ID" },
       { "field": "race", "name": "Race" },
       { "field": "hiv_status", "name": "HIV Status" }
@@ -256,6 +256,10 @@
         "fields": ["ethnicity", "gender", "species", "race"]
       },
       {
+        "title": "Resource",
+        "fields": ["dataset"]
+      },
+      {
         "title": "Diagnosis",
         "fields": [
           "arthxbase",
@@ -263,8 +267,31 @@
           "bshcvstat",
           "cd4nadir",
           "status",
-          "hiv_status",
-          "strain"
+          "hiv_status"
+        ]
+      },
+      {
+        "title": "Comorbidity",
+        "fields": [
+          "frstcncrd",
+          "frstdmd",
+          "frstdmmd",
+          "frsthtnd",
+          "frsthtnmd"
+        ]
+      }, {
+        "title": "HIV History",
+        "fields": [
+          "cd4nadir",
+          "fcd4lowd",
+          "fposdate",
+          "frstaidd",
+          "lastafrd",
+          "lastcond",
+          "lastcontact",
+          "lcd4higd",
+          "lnegdate",
+          "status"
         ]
       },
       {
@@ -282,8 +309,17 @@
         ]
       },
       {
-        "title": "Resource",
-        "fields": ["dataset"]
+        "title": "Experiment",
+        "fields": [
+          "virus_type",
+          "virus_subtype",
+          "analyte_type",
+          "biospecimen_anatomic_site",
+          "cell_line",
+          "sample_type",
+          "composition",
+          "strain"
+        ]
       }]
     },
     "phenotypeNameMapping": {

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -63,7 +63,7 @@
         {
           "name": "NIAID TB Environment",
           "icon": "data-explore",
-          "body": "Explore data from the NIAID TB Portals Program and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
+          "body": "Explore data from <a href='https://qa-test2.planx-pla.net/'>the NIAID TB Portals Program</a> and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
           "external_link": "https://qa-test2.planx-pla.net/"
         },
         {

--- a/data/config/ndef-qa.json
+++ b/data/config/ndef-qa.json
@@ -63,7 +63,7 @@
         {
           "name": "NIAID TB Environment",
           "icon": "data-explore",
-          "body": "Explore data from <a href='https://qa-test2.planx-pla.net/'>the NIAID TB Portals Program</a> and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
+          "body": "Explore data from the NIAID <a href='https://tbportals.niaid.nih.gov/'>TB Portals</a> Program and <a href='https://tbportals.niaid.nih.gov/'>PATRIC</a>, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
           "external_link": "https://qa-test2.planx-pla.net/"
         },
         {

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -189,7 +189,22 @@
       },
       "dataset": {
         "chartType": "pie",
-        "title": "Dataset",
+        "title": "Resources",
+        "chartRow": 0
+      },
+      "data_format": {
+        "chartType": "bar",
+        "title": "Data Format",
+        "chartRow": 0
+      },
+      "data_type": {
+        "chartType": "pie",
+        "title": "Data Type",
+        "chartRow": 0
+      },
+      "experimental_strategies": {
+        "chartType": "bar",
+        "title": "Experimental Strategies",
         "chartRow": 0
       },
       "species": {
@@ -200,41 +215,21 @@
       "gender": {
         "chartType": "pie",
         "title": "Gender",
-        "chartRow": 0
-      },
-      "status": {
-        "chartType": "pie",
-        "title": "HIV Status",
-        "chartRow": 0
-      },
-      "strain": {
-        "chartType": "pie",
-        "title": "Strain",
-        "chartRow": 0
-      },
-      "amikacin_res_phenotype": {
-        "chartType": "bar",
-        "title": "Amikacin Res Phenotype",
         "chartRow": 1
       },
-      "capreomycin_res_phenotype": {
+      "race": {
         "chartType": "pie",
-        "title": "Capreomycin Res Phenotype",
+        "title": "Race",
         "chartRow": 1
       },
-      "isoniazid_res_phenotype": {
-        "chartType": "bar",
-        "title": "Isoniazid Res Phenotype",
-        "chartRow": 1
-      },
-      "kanamycin_res_phenotype": {
+      "ethnicity": {
         "chartType": "pie",
-        "title": "Kanamycin Res Phenotype",
+        "title": "Ethnicity",
         "chartRow": 1
       },
-      "ofloxacin_res_phenotype": {
-        "chartType": "bar",
-        "title": "Ofloxacin Res Phenotype",
+      "biospecimen_anatomic_site": {
+        "chartType": "pie",
+        "title": "Biospecimen Anatomic Site",
         "chartRow": 1
       }
     },
@@ -248,16 +243,17 @@
       { "field": "species", "name": "Genus Species" },
       { "field": "submitter_id", "name": "Submitter ID" },
       { "field": "race", "name": "Race" },
-      { "field": "hiv_status", "name": "HIV Status" }
+      { "field": "hiv_status", "name": "HIV Status" },
+      { "field": "study_submitter_id", "name": "Study"}
     ],
     "filterConfig": {
       "tabs": [{
-        "title": "Subject",
-        "fields": ["ethnicity", "gender", "species", "race"]
+        "title": "Resource",
+        "fields": ["dataset", "data_format", "data_type"]
       },
       {
-        "title": "Resource",
-        "fields": ["dataset"]
+        "title": "Subject",
+        "fields": ["ethnicity", "gender", "species", "race", "experimental_strategies"]
       },
       {
         "title": "Diagnosis",
@@ -321,11 +317,6 @@
           "strain"
         ]
       }]
-    },
-    "phenotypeNameMapping": {
-      "NDE: TB": "_type_of_resistances",
-      "NDE: FLU": "virus_subtype",
-      "NDE: AIDS": "status"
     }
   }
 }

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -212,31 +212,6 @@
         "title": "Strain",
         "chartRow": 0
       },
-      "dataset": {
-        "chartType": "pie",
-        "title": "Dataset",
-        "chartRow": 0
-      },
-      "species": {
-        "chartType": "bar",
-        "title": "Genus species",
-        "chartRow": 0
-      },
-      "gender": {
-        "chartType": "pie",
-        "title": "Gender",
-        "chartRow": 0
-      },
-      "status": {
-        "chartType": "bar",
-        "title": "HIV Status",
-        "chartRow": 0
-      },
-      "strain": {
-        "chartType": "pie",
-        "title": "Strain",
-        "chartRow": 0
-      },
       "amikacin_res_phenotype": {
         "chartType": "bar",
         "title": "Amikacin Res Phenotype",

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -63,7 +63,7 @@
         {
           "name": "NIAID TB Environment",
           "icon": "data-explore",
-          "body": "Explore data from the NIAID TB Portals Program and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
+          "body": "Explore data from <a href='https://tb.niaiddata.org'>the NIAID TB Portals Program</a> and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
           "external_link": "https://tb.niaiddata.org"
         },
         {

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -55,7 +55,7 @@
       "buttons": [
         {
           "name": "ImmPort",
-          "body": "Explore ImmPort, a resource funded by the NIH, NIAID, and DAIT in support of the NIH mission to share data with the public. Data is provided by NIH-funded programs and other research organizations.",
+          "body": "Visit ImmPort, a resource funded by the NIH, NIAID, and DAIT in support of the NIH mission to share data with the public. Data is provided by NIH-funded programs and other research organizations.",
           "external_link": "https://www.immport.org/home",
           "external_link_text": "Visit Website",
           "logo": "/custom/logo/immport-main-icon.png"
@@ -69,13 +69,13 @@
         {
           "name": "NIAID AIDS Environment",
           "icon": "data-explore",
-          "body": "Explore the NIAID's Multicenter Acquired Immunodeficiency Syndrome Cohort Study (MACS) and Women's Interagency HIV Study (WIHS).",
+          "body": "Explore data from the NIAID Multicenter Acquired Immunodeficiency Syndrome Cohort Study (MACS) and Women's Interagency HIV Study (WIHS).",
           "external_link": "https://aids.niaiddata.org"
         },
         {
           "name": "NIAID Flu Environment",
           "icon": "data-explore",
-          "body": "Explore a collection of Influenza related studies from the NIAID Divison of Microbiology & Infectious Diseases.",
+          "body": "Explore data from a collection of Influenza related studies funded by the NIAID Divison of Microbiology & Infectious Diseases (DMID).",
           "external_link": "https://flu.niaiddata.org"
         }
       ]

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -189,15 +189,78 @@
       },
       "dataset": {
         "chartType": "pie",
-        "title": "Dataset"
+        "title": "Dataset",
+        "chartRow": 0
       },
       "species": {
         "chartType": "bar",
-        "title": "Genus species"
+        "title": "Genus species",
+        "chartRow": 0
       },
       "gender": {
         "chartType": "pie",
-        "title": "Gender"
+        "title": "Gender",
+        "chartRow": 0
+      },
+      "status": {
+        "chartType": "pie",
+        "title": "HIV Status",
+        "chartRow": 0
+      },
+      "strain": {
+        "chartType": "pie",
+        "title": "Strain",
+        "chartRow": 0
+      },
+      "dataset": {
+        "chartType": "pie",
+        "title": "Dataset",
+        "chartRow": 0
+      },
+      "species": {
+        "chartType": "bar",
+        "title": "Genus species",
+        "chartRow": 0
+      },
+      "gender": {
+        "chartType": "pie",
+        "title": "Gender",
+        "chartRow": 0
+      },
+      "status": {
+        "chartType": "bar",
+        "title": "HIV Status",
+        "chartRow": 0
+      },
+      "strain": {
+        "chartType": "pie",
+        "title": "Strain",
+        "chartRow": 0
+      },
+      "amikacin_res_phenotype": {
+        "chartType": "bar",
+        "title": "Amikacin Res Phenotype",
+        "chartRow": 1
+      },
+      "capreomycin_res_phenotype": {
+        "chartType": "pie",
+        "title": "capreomycin_res_phenotype",
+        "chartRow": 1
+      },
+      "isoniazid_res_phenotype": {
+        "chartType": "bar",
+        "title": "isoniazid_res_phenotype",
+        "chartRow": 1
+      },
+      "kanamycin_res_phenotype": {
+        "chartType": "pie",
+        "title": "kanamycin_res_phenotype",
+        "chartRow": 1
+      },
+      "ofloxacin_res_phenotype": {
+        "chartType": "bar",
+        "title": "ofloxacin_res_phenotype",
+        "chartRow": 1
       }
     },
     "fieldMapping" : [
@@ -225,7 +288,8 @@
           "bshcvstat",
           "cd4nadir",
           "status",
-          "hiv_status"
+          "hiv_status",
+          "strain"
         ]
       },
       {
@@ -246,34 +310,6 @@
         "title": "Resource",
         "fields": ["dataset"]
       }]
-    },
-    "tableConfig": {
-      "fields": [
-        "dataset",
-        "studyAccession",
-        "phenotype",
-        "gender",
-        "ethnicity",
-        "strain",
-        "species",
-        "submitter_id",
-        "race",
-        "arthxbase",
-        "bshbvstat",
-        "bshcvstat",
-        "cd4nadir",
-        "status",
-        "hiv_status",
-        "amikacin_res_phenotype",
-        "capreomycin_res_phenotype",
-        "isoniazid_res_phenotype",
-        "kanamycin_res_phenotype",
-        "ofloxacin_res_phenotype",
-        "pyrazinamide_res_phenotype",
-        "rifampicin_res_phenotype",
-        "rifampin_res_phenotype",
-        "streptomycin_res_phenotype"
-      ]
     },
     "phenotypeNameMapping": {
       "NDE: TB": "_type_of_resistances",

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -219,22 +219,22 @@
       },
       "capreomycin_res_phenotype": {
         "chartType": "pie",
-        "title": "capreomycin_res_phenotype",
+        "title": "Capreomycin Res Phenotype",
         "chartRow": 1
       },
       "isoniazid_res_phenotype": {
         "chartType": "bar",
-        "title": "isoniazid_res_phenotype",
+        "title": "Isoniazid Res Phenotype",
         "chartRow": 1
       },
       "kanamycin_res_phenotype": {
         "chartType": "pie",
-        "title": "kanamycin_res_phenotype",
+        "title": "Kanamycin Res Phenotype",
         "chartRow": 1
       },
       "ofloxacin_res_phenotype": {
         "chartType": "bar",
-        "title": "ofloxacin_res_phenotype",
+        "title": "Ofloxacin Res Phenotype",
         "chartRow": 1
       }
     },
@@ -245,7 +245,7 @@
       { "field": "gender", "name": "Gender" },
       { "field": "ethnicity", "name": "Ethnicity" },
       { "field": "strain", "name": "Strain" },
-      { "field": "species", "name": "Genus species" },
+      { "field": "species", "name": "Genus Species" },
       { "field": "submitter_id", "name": "Submitter ID" },
       { "field": "race", "name": "Race" },
       { "field": "hiv_status", "name": "HIV Status" }
@@ -256,6 +256,10 @@
         "fields": ["ethnicity", "gender", "species", "race"]
       },
       {
+        "title": "Resource",
+        "fields": ["dataset"]
+      },
+      {
         "title": "Diagnosis",
         "fields": [
           "arthxbase",
@@ -263,8 +267,31 @@
           "bshcvstat",
           "cd4nadir",
           "status",
-          "hiv_status",
-          "strain"
+          "hiv_status"
+        ]
+      },
+      {
+        "title": "Comorbidity",
+        "fields": [
+          "frstcncrd",
+          "frstdmd",
+          "frstdmmd",
+          "frsthtnd",
+          "frsthtnmd"
+        ]
+      }, {
+        "title": "HIV History",
+        "fields": [
+          "cd4nadir",
+          "fcd4lowd",
+          "fposdate",
+          "frstaidd",
+          "lastafrd",
+          "lastcond",
+          "lastcontact",
+          "lcd4higd",
+          "lnegdate",
+          "status"
         ]
       },
       {
@@ -282,8 +309,17 @@
         ]
       },
       {
-        "title": "Resource",
-        "fields": ["dataset"]
+        "title": "Experiment",
+        "fields": [
+          "virus_type",
+          "virus_subtype",
+          "analyte_type",
+          "biospecimen_anatomic_site",
+          "cell_line",
+          "sample_type",
+          "composition",
+          "strain"
+        ]
       }]
     },
     "phenotypeNameMapping": {

--- a/data/config/ndef.json
+++ b/data/config/ndef.json
@@ -63,7 +63,7 @@
         {
           "name": "NIAID TB Environment",
           "icon": "data-explore",
-          "body": "Explore data from <a href='https://tb.niaiddata.org'>the NIAID TB Portals Program</a> and PATRIC, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
+          "body": "Explore data from the NIAID <a href='https://tbportals.niaid.nih.gov/'>TB Portals</a> Program and <a href='https://tbportals.niaid.nih.gov/'>PATRIC</a>, the all-bacterial Bioinformatics Database and Analysis Resource Center.",
           "external_link": "https://tb.niaiddata.org"
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,9 +1736,9 @@
       }
     },
     "@gen3/ui-component": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.3.5.tgz",
-      "integrity": "sha512-BR/Vbnukum+ybBchRH7YWacK4usm5TYlZbHPoLIpjqGHrTiwXoexYxAta/6QYdNuc8o6X+MHwKnjGgTz3WRQ6A==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.3.6.tgz",
+      "integrity": "sha512-22CPw0ks7fYncrVaR9kNPYaLMDnLBzsTd/NJJNNFpVKCsBZX/I6DQfWumHnyjZJ4h3fI2t/+z/5tiA4pRXcTwQ==",
       "requires": {
         "babel-loader": "^8.0.5",
         "postcss-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
     "@gen3/guppy": "0.3.6",
-    "@gen3/ui-component": "0.3.5",
+    "@gen3/ui-component": "0.3.6",
     "@storybook/addon-actions": "^5.0.0",
     "@storybook/react": "^5.0.0",
     "brace": "^0.10.0",

--- a/src/Explorer/Explorer.less
+++ b/src/Explorer/Explorer.less
@@ -50,3 +50,11 @@
   color: #3283c8;
   fill: #3283c8;
 }
+
+.explorer__visualizations .summary-chart-group {
+  margin-bottom: 20px;
+}
+
+.explorer__visualizations .summary-pie-chart__legend-item {
+  margin-bottom: 10px;
+}

--- a/src/components/IndexButtonBar.css
+++ b/src/components/IndexButtonBar.css
@@ -19,6 +19,7 @@
   margin: 20px 20px;
   border: 1px solid var(--g3-color__silver);
   border-radius: 4px;
+  position: relative;
 }
 
 .index-button-bar__thumbnail-title {
@@ -26,10 +27,16 @@
 }
 
 .index-button-bar__thumbnail-text {
-  margin-top: 30px;
+  margin: 30px 0 50px 0;
   border-top: 1px solid #e7e7e7;
   padding: 10px 10px;
   text-align: left;
+}
+
+.index-button-bar__button-group {
+  position: absolute;
+  bottom: 25px;
+  left: 50%;
 }
 
 .index-button-bar__icon {
@@ -40,6 +47,8 @@
 
 .index-button-bar__item {
   margin: 10px;
+  position: relative;
+  left: -50%;
 }
 
 .index-button-bar__header {

--- a/src/components/IndexButtonBar.jsx
+++ b/src/components/IndexButtonBar.jsx
@@ -30,7 +30,10 @@ class IndexButtonBar extends Component {
                         height='90px'
                       /> : <img height='70px' src={item.logo} alt='' /> }
                   </div>
-                  <div className='body-typo index-button-bar__thumbnail-text'>{item.body}</div>
+                  <div
+                    className='body-typo index-button-bar__thumbnail-text'
+                    dangerouslySetInnerHTML={{ __html: item.body }}
+                  />
                   <div className='index-button-bar__button-group'>
                     { Object.prototype.hasOwnProperty.call(item, 'internal_link') &&
                     <Button


### PR DESCRIPTION
This PR removes table from data explorer. And also allows more rows of charts to the visualization area. 

### New Features
  - Allows more rows of charts to the visualization area. 

### Breaking Changes


### Bug Fixes


### Improvements
  - removes table from data explorer

### Dependency updates


### Deployment changes

