### PR TITLE
fix(no-explorer): add explorer config to default

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -129,5 +129,6 @@
         "fields": [ ]
       }]
     }
-  }
+  },
+  "dataExplorerConfig": {}
 }

--- a/src/Explorer/index.jsx
+++ b/src/Explorer/index.jsx
@@ -51,7 +51,8 @@ function flattenHistograms(listOfHistograms) {
   return result;
 }
 
-const filterValuesLastList = config.dataExplorerConfig.filterValuesLastList || [
+const filterValuesLastList = (config.dataExplorerConfig &&
+config.dataExplorerConfig.filterValuesLastList) || [
   'not specified',
   'unspecified',
   'unknown',


### PR DESCRIPTION
avoid crashes because the config doesn't contain "dataExplorerConfig" when using the default config