### PR TITLE
fix(flat): wrap flat so that Edge works

### DIFF
--- a/src/DatasetBrowser/index.jsx
+++ b/src/DatasetBrowser/index.jsx
@@ -48,6 +48,19 @@ function checkIfFiltersApply(filtersApplied, row) {
   return true;
 }
 
+function flatArray(list) {
+  if (Array.prototype.flat) {
+    list.flat();
+  }
+  // Use MDN alternative implementation
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#Alternative
+  function flatDeep(arr, d = 1) {
+    return d > 0 ? arr.reduce((acc, val) => acc.concat(Array.isArray(val)
+      ? flatDeep(val, d - 1) : val), []) : arr.slice();
+  }
+  return flatDeep(list, Infinity);
+}
+
 class DatasetBrowser extends React.Component {
   constructor(props) {
     super(props);
@@ -151,7 +164,7 @@ class DatasetBrowser extends React.Component {
       this.allData = this.allData.concat(parentCommonsData);
       return this.obtainAllSubcommonsData();
     }).then((subCommonsData) => {
-      const data = subCommonsData.flat();
+      const data = flatArray(subCommonsData);
       if (data.length > 0) {
         this.allData = this.allData.concat(data);
       }

--- a/src/DatasetBrowser/index.jsx
+++ b/src/DatasetBrowser/index.jsx
@@ -50,7 +50,7 @@ function checkIfFiltersApply(filtersApplied, row) {
 
 function flatArray(list) {
   if (Array.prototype.flat) {
-    list.flat();
+    return list.flat();
   }
   // Use MDN alternative implementation
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#Alternative


### PR DESCRIPTION
There's a error "object doesn't support property or method "flat"" in MS Edge browser. This PR add alternative implementation to flat function to avoid the error. 

### Bug Fixes

Fix Array.prototype.flat in MS Edge browser